### PR TITLE
Refactored delete prompt code and added an option to disable it

### DIFF
--- a/qiskit_ibm_experiment/service/ibm_experiment_service.py
+++ b/qiskit_ibm_experiment/service/ibm_experiment_service.py
@@ -121,6 +121,7 @@ class IBMExperimentService:
         self.set_option(**kwargs)
 
     def set_option(self, **kwargs):
+        """Sets the options given as keywords"""
         for name, value in kwargs.items():
             if name in self.options:
                 self.options[name] = value

--- a/qiskit_ibm_experiment/service/ibm_experiment_service.py
+++ b/qiskit_ibm_experiment/service/ibm_experiment_service.py
@@ -708,8 +708,10 @@ class IBMExperimentService:
         Raises:
             IBMApiError: If the request to the server failed.
         """
-        if not self._confirm_delete("Are you sure you want to delete the experiment? "
-                "Results and plots for the experiment will also be deleted. [y/N]: "):
+        if not self._confirm_delete(
+            "Are you sure you want to delete the experiment? "
+            "Results and plots for the experiment will also be deleted. [y/N]: "
+        ):
             return
         try:
             self._api_client.experiment_delete(experiment_id)
@@ -841,7 +843,9 @@ class IBMExperimentService:
                 result_id, json.dumps(request, cls=json_encoder)
             )
 
-    def _confirm_delete(self, msg):
+    def _confirm_delete(self, msg: str) -> bool:
+        """Confirms a delete command; if the options indicate a prompt should be
+        dislayed, display one and verify the user input"""
         if not self.options["prompt_for_delete"]:
             return True
         confirmation = input("\n" + msg)
@@ -1250,7 +1254,9 @@ class IBMExperimentService:
         Raises:
             IBMApiError: If the request to the server failed.
         """
-        if not self._confirm_delete("Are you sure you want to delete the analysis result? [y/N]: "):
+        if not self._confirm_delete(
+            "Are you sure you want to delete the analysis result? [y/N]: "
+        ):
             return
         try:
             self._api_client.analysis_result_delete(result_id)
@@ -1375,7 +1381,9 @@ class IBMExperimentService:
         Raises:
             IBMApiError: If the request to the server failed.
         """
-        if not self._confirm_delete("Are you sure you want to delete the experiment plot? [y/N]: "):
+        if not self._confirm_delete(
+            "Are you sure you want to delete the experiment plot? [y/N]: "
+        ):
             return
         try:
             self._api_client.experiment_plot_delete(experiment_id, figure_name)

--- a/qiskit_ibm_experiment/service/ibm_experiment_service.py
+++ b/qiskit_ibm_experiment/service/ibm_experiment_service.py
@@ -72,6 +72,7 @@ class IBMExperimentService:
     """
 
     _default_preferences = {"auto_save": False}
+    _default_options = {"prompt_for_delete": True}
     _DEFAULT_AUTHENTICATION_PREFIX = "/v2/users/loginWithToken"
     _DEFAULT_EXPERIMENT_PREFIX = "/resultsdb"
 
@@ -82,6 +83,7 @@ class IBMExperimentService:
         name: Optional[str] = None,
         proxies: Optional[dict] = None,
         verify: Optional[bool] = None,
+        **kwargs,
     ) -> None:
         """IBMExperimentService constructor.
 
@@ -115,6 +117,13 @@ class IBMExperimentService:
         self._api_client = ExperimentClient(
             self._access_token, db_url, self._additional_params
         )
+        self.options = self._default_options
+        self.set_option(**kwargs)
+
+    def set_option(self, **kwargs):
+        for name, value in kwargs.items():
+            if name in self.options:
+                self.options[name] = value
 
     def get_access_token(self, auth_url, api_token=None):
         """Authenticates to the server with the API token, receiving access token
@@ -699,13 +708,9 @@ class IBMExperimentService:
         Raises:
             IBMApiError: If the request to the server failed.
         """
-        confirmation = input(
-            "\nAre you sure you want to delete the experiment? "
-            "Results and plots for the experiment will also be deleted. [y/N]: "
-        )
-        if confirmation not in ("y", "Y"):
+        if not self._confirm_delete("Are you sure you want to delete the experiment? "
+                "Results and plots for the experiment will also be deleted. [y/N]: "):
             return
-
         try:
             self._api_client.experiment_delete(experiment_id)
         except RequestsApiError as api_err:
@@ -835,6 +840,14 @@ class IBMExperimentService:
             self._api_client.analysis_result_update(
                 result_id, json.dumps(request, cls=json_encoder)
             )
+
+    def _confirm_delete(self, msg):
+        if not self.options["prompt_for_delete"]:
+            return True
+        confirmation = input("\n" + msg)
+        if confirmation not in ("y", "Y"):
+            return False
+        return True
 
     def _analysis_result_to_api(
         self,
@@ -1237,12 +1250,8 @@ class IBMExperimentService:
         Raises:
             IBMApiError: If the request to the server failed.
         """
-        confirmation = input(
-            "\nAre you sure you want to delete the analysis result? [y/N]: "
-        )
-        if confirmation not in ("y", "Y"):
+        if not self._confirm_delete("Are you sure you want to delete the analysis result? [y/N]: "):
             return
-
         try:
             self._api_client.analysis_result_delete(result_id)
         except RequestsApiError as api_err:
@@ -1366,12 +1375,8 @@ class IBMExperimentService:
         Raises:
             IBMApiError: If the request to the server failed.
         """
-        confirmation = input(
-            "\nAre you sure you want to delete the experiment plot? [y/N]: "
-        )
-        if confirmation not in ("y", "Y"):
+        if not self._confirm_delete("Are you sure you want to delete the experiment plot? [y/N]: "):
             return
-
         try:
             self._api_client.experiment_plot_delete(experiment_id, figure_name)
         except RequestsApiError as api_err:

--- a/test/service/test_experiment.py
+++ b/test/service/test_experiment.py
@@ -23,8 +23,8 @@ from qiskit_ibm_experiment import IBMExperimentService
 @skipIf(
     not os.environ.get("QISKIT_IBM_USE_STAGING_CREDENTIALS", ""), "Only runs on staging"
 )
-class TestExperimentPreferences(IBMTestCase):
-    """Test experiment preferences."""
+class TestExperiment(IBMTestCase):
+    """Test experiment."""
 
     @classmethod
     def setUpClass(cls):
@@ -52,6 +52,23 @@ class TestExperimentPreferences(IBMTestCase):
         """Test setting preferences."""
         self.service.preferences["auto_save"] = True
         self.assertTrue(self.service.preferences["auto_save"])
+
+    def test_default_options(self):
+        """Test getting default options."""
+        self.assertTrue(self.service.options["prompt_for_delete"])
+
+    def test_set_options(self):
+        """Test setting options."""
+        original_options = self.service.options
+        self.service.set_option(prompt_for_delete=False)
+        self.assertFalse(self.service.options["prompt_for_delete"])
+        self.service.options = original_options
+
+    def test_prompt_for_delete_options(self):
+        original_options = self.service.options
+        self.service.set_option(prompt_for_delete=False)
+        self.assertTrue(self.service._confirm_delete("")) # should work without mock patch
+        self.service.options = original_options
 
 
 if __name__ == "__main__":

--- a/test/service/test_experiment.py
+++ b/test/service/test_experiment.py
@@ -65,6 +65,7 @@ class TestExperiment(IBMTestCase):
         self.service.options = original_options
 
     def test_prompt_for_delete_options(self):
+        """Test delete prompt is not displayed given the corresponding option"""
         original_options = self.service.options
         self.service.set_option(prompt_for_delete=False)
         self.assertTrue(

--- a/test/service/test_experiment.py
+++ b/test/service/test_experiment.py
@@ -67,7 +67,9 @@ class TestExperiment(IBMTestCase):
     def test_prompt_for_delete_options(self):
         original_options = self.service.options
         self.service.set_option(prompt_for_delete=False)
-        self.assertTrue(self.service._confirm_delete("")) # should work without mock patch
+        self.assertTrue(
+            self.service._confirm_delete("")
+        )  # should work without mock patch
         self.service.options = original_options
 
 


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Fixes issue #16.


### Details and comments
This PR addresses issue #16 by adding an `options` field in `IBMExperimentService`, intended to be changed via `IBMExperimentService.set_option()`, with the `prompt_for_delete` option disabling the confirmation prompt used when deleting experiment/analysis result/figure. This PR also slightly refactored the code displaying those prompts so they all use the same `_confirm_delete()` method.

