### PR TITLE
Update QISKIT_IBM_STAGING_API_URL example

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -225,7 +225,7 @@ Run integration tests against IBM Quantum
 ```bash
 QISKIT_IBM_USE_STAGING_CREDENTIALS=True
 QISKIT_IBM_STAGING_API_TOKEN=...                                            # IBM Quantum API token
-QISKIT_IBM_STAGING_API_URL=https://auth.quantum-computing.ibm.com/api       # IBM Quantum API URL
+QISKIT_IBM_STAGING_API_URL=https://api-dev.quantum-computing.ibm.com        # IBM Quantum API URL
 ```
 
 Run unit tests


### PR DESCRIPTION

### Summary

The example URL for `QISKIT_IBM_STAGING_API_URL` doesn't work, you
get something like this:

>py38 run-test: commands[1] | stestr run -n test/service/test_experiment_server_integration.py
TestExperimentServerIntegration.setUpClass:INFO:2022-04-25 09:28:02,363: Error while setting the service/provider: '404 Client Error: Not Found for url: https://auth-dev.quantum-computing.ibm.com/api/v2/version. There is no method to handle GET /v2/version, Error code: 2411.'

### Details and comments

Per the discussion [here](https://github.com/Qiskit/qiskit-ibm-experiment/pull/35#issuecomment-1108733726).

