### PR TITLE
Dataclasses

### DIFF
--- a/qiskit_ibm_experiment/service/dataclasses.py
+++ b/qiskit_ibm_experiment/service/dataclasses.py
@@ -15,6 +15,7 @@ from dataclasses import dataclass
 from typing import Optional, List, Dict, Any
 from datetime import datetime
 
+
 @dataclass
 class ExperimentData:
     experiment_id: str
@@ -31,10 +32,34 @@ class ExperimentData:
     group: str
     project: str
     owner: str
-    creation_datetime: datetime
-    start_datetime: datetime
-    end_datetime: datetime
-    updated_datetime: datetime
+    creation_datetime: Optional[datetime] = None
+    start_datetime: Optional[datetime] = None
+    end_datetime: Optional[datetime] = None
+    updated_datetime: Optional[datetime] = None
+
+    def __str__(self):
+        ret = ""
+        ret += f"Experiment: {self.experiment_type}"
+        ret += f"\nExperiment ID: {self.experiment_id}"
+        if self.backend:
+            ret += f"\nBackend: {self.backend}"
+        if self.tags:
+            ret += f"\nTags: {self.tags}"
+        ret += f"\nHub\Group\Project: {self.hub}\{self.group}\{self.project}"
+        if self.creation_datetime:
+            ret += f"\nCreated at: {self.creation_datetime}"
+        if self.start_datetime:
+            ret += f"\nStarted at: {self.start_datetime}"
+        if self.end_datetime:
+            ret += f"\nEnded at: {self.end_datetime}"
+        if self.updated_datetime:
+            ret += f"\nUpdated at: {self.updated_datetime}"
+        if self.metadata:
+            ret += f"\nMetadata: {self.metadata}"
+        if self.figure_names:
+            ret += f"\nFigures: {self.figure_names}"
+        return ret
+
 
 @dataclass
 class AnalysisResultData:
@@ -49,3 +74,17 @@ class AnalysisResultData:
     backend_name: str
     creation_datetime: datetime
 
+    def __str__(self):
+        ret = f"Result {self.result_type}"
+        ret += f"\nResult ID: {self.result_id}"
+        ret += f"\nExperiment ID: {self.experiment_id}"
+        ret += f"\nBackend: {self.backend_name}"
+        ret += f"\nQuality: {self.quality}"
+        ret += f"\nVerified: {self.verified}"
+        ret += f"\nDevice components: {self.device_components}"
+        ret += f"\nData: {self.result_data}"
+        if self.tags:
+            ret += f"\nTags: {self.tags}"
+        if self.creation_datetime:
+            ret += f"\nCreated at: {self.creation_datetime}"
+        return ret

--- a/qiskit_ibm_experiment/service/dataclasses.py
+++ b/qiskit_ibm_experiment/service/dataclasses.py
@@ -1,0 +1,52 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2021.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Dataclasses for returned results"""
+from dataclasses import dataclass
+from typing import Optional, List, Dict, Any
+from datetime import datetime
+from . import ResultQuality
+
+@dataclass
+class ExperimentData:
+    experiment_id: str
+    parent_id: Optional[str]
+    experiment_type: str
+    backend: str
+    tags: List[str]
+    job_ids: List[str]
+    share_level: str
+    metadata: Dict[str, str]
+    figure_names: List[str]
+    notes: Optional[str]
+    hub: str
+    group: str
+    project: str
+    owner: str
+    creation_datetime: datetime
+    start_datetime: datetime
+    end_datetime: datetime
+    updated_datetime: datetime
+
+@dataclass
+class AnalysisResultData:
+    experiment_id: str
+    result_id: str
+    result_type: str
+    result_data: Dict[str, Any]
+    device_components: List[str]
+    quality: ResultQuality
+    verified: bool
+    tags: List[str]
+    backend_name: str
+    creation_datetime: datetime
+

--- a/qiskit_ibm_experiment/service/dataclasses.py
+++ b/qiskit_ibm_experiment/service/dataclasses.py
@@ -18,6 +18,8 @@ from datetime import datetime
 
 @dataclass
 class ExperimentData:
+    """Dataclass for experiments"""
+
     experiment_id: str
     parent_id: Optional[str]
     experiment_type: str
@@ -45,7 +47,7 @@ class ExperimentData:
             ret += f"\nBackend: {self.backend}"
         if self.tags:
             ret += f"\nTags: {self.tags}"
-        ret += f"\nHub\Group\Project: {self.hub}\{self.group}\{self.project}"
+        ret += f"\nHub\\Group\\Project: {self.hub}\\{self.group}\\{self.project}"
         if self.creation_datetime:
             ret += f"\nCreated at: {self.creation_datetime}"
         if self.start_datetime:
@@ -60,9 +62,16 @@ class ExperimentData:
             ret += f"\nFigures: {self.figure_names}"
         return ret
 
+    def __getitem__(self, item):
+        if hasattr(self, item):
+            return getattr(self, item)
+        return None
+
 
 @dataclass
 class AnalysisResultData:
+    """Dataclass for experiment analysis results"""
+
     experiment_id: str
     result_id: str
     result_type: str
@@ -73,6 +82,8 @@ class AnalysisResultData:
     tags: List[str]
     backend_name: str
     creation_datetime: datetime
+    updated_datetime: Optional[datetime] = None
+    chisq: Optional[float] = None
 
     def __str__(self):
         ret = f"Result {self.result_type}"
@@ -83,8 +94,17 @@ class AnalysisResultData:
         ret += f"\nVerified: {self.verified}"
         ret += f"\nDevice components: {self.device_components}"
         ret += f"\nData: {self.result_data}"
+        if self.chisq:
+            ret += f"\nChi Square: {self.chisq}"
         if self.tags:
             ret += f"\nTags: {self.tags}"
         if self.creation_datetime:
             ret += f"\nCreated at: {self.creation_datetime}"
+        if self.updated_datetime:
+            ret += f"\nUpdated at: {self.updated_datetime}"
         return ret
+
+    def __getitem__(self, item):
+        if hasattr(self, item):
+            return getattr(self, item)
+        return None

--- a/qiskit_ibm_experiment/service/dataclasses.py
+++ b/qiskit_ibm_experiment/service/dataclasses.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2021.
+# (C) Copyright IBM 2022.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -14,7 +14,6 @@
 from dataclasses import dataclass
 from typing import Optional, List, Dict, Any
 from datetime import datetime
-from . import ResultQuality
 
 @dataclass
 class ExperimentData:
@@ -44,7 +43,7 @@ class AnalysisResultData:
     result_type: str
     result_data: Dict[str, Any]
     device_components: List[str]
-    quality: ResultQuality
+    quality: "ResultQuality"
     verified: bool
     tags: List[str]
     backend_name: str

--- a/qiskit_ibm_experiment/service/experiment_dataclasses.py
+++ b/qiskit_ibm_experiment/service/experiment_dataclasses.py
@@ -68,14 +68,14 @@ class AnalysisResultData:
 
     experiment_id: str
     result_id: str
-    result_type: str
-    result_data: Dict[str, Any]
-    device_components: List[str]
-    quality: "ResultQuality"
-    verified: bool
-    tags: List[str]
-    backend_name: str
-    creation_datetime: datetime
+    result_type: Optional[str] = None
+    result_data: Optional[Dict[str, Any]] = field(default_factory=lambda: {})
+    device_components: Optional[List[str]] = field(default_factory=lambda: [])
+    quality: Optional[str] = None
+    verified: Optional[bool] = False
+    tags: Optional[List[str]] = field(default_factory=lambda: [])
+    backend_name: Optional[str] = None
+    creation_datetime: Optional[datetime] = None
     updated_datetime: Optional[datetime] = None
     chisq: Optional[float] = None
 
@@ -97,12 +97,3 @@ class AnalysisResultData:
         if self.updated_datetime:
             ret += f"\nUpdated at: {self.updated_datetime}"
         return ret
-
-exp1 = ExperimentData()
-exp2 = ExperimentData()
-exp1.tags.append("foo")
-exp2.tags.append("bar")
-
-print(exp1)
-print("****")
-print(exp2)

--- a/qiskit_ibm_experiment/service/experiment_dataclasses.py
+++ b/qiskit_ibm_experiment/service/experiment_dataclasses.py
@@ -11,7 +11,7 @@
 # that they have been altered from the originals.
 
 """Dataclasses for returned results"""
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Optional, List, Dict, Any
 from datetime import datetime
 
@@ -21,19 +21,19 @@ class ExperimentData:
     """Dataclass for experiments"""
 
     experiment_id: str
-    parent_id: Optional[str]
-    experiment_type: str
-    backend: str
-    tags: List[str]
-    job_ids: List[str]
-    share_level: str
-    metadata: Dict[str, str]
-    figure_names: List[str]
-    notes: Optional[str]
-    hub: str
-    group: str
-    project: str
-    owner: str
+    parent_id: Optional[str] = None
+    experiment_type: str = None
+    backend: Optional[str] = None
+    tags: Optional[List[str]] = field(default_factory=lambda: [])
+    job_ids: Optional[List[str]] = field(default_factory=lambda: [])
+    share_level: Optional[str] = None
+    metadata: Optional[Dict[str, str]] = field(default_factory=lambda: {})
+    figure_names: Optional[List[str]] = field(default_factory=lambda: [])
+    notes: Optional[str] = None
+    hub: Optional[str] = None
+    group: Optional[str] = None
+    project: Optional[str] = None
+    owner: Optional[str] = None
     creation_datetime: Optional[datetime] = None
     start_datetime: Optional[datetime] = None
     end_datetime: Optional[datetime] = None
@@ -61,12 +61,6 @@ class ExperimentData:
         if self.figure_names:
             ret += f"\nFigures: {self.figure_names}"
         return ret
-
-    def __getitem__(self, item):
-        if hasattr(self, item):
-            return getattr(self, item)
-        return None
-
 
 @dataclass
 class AnalysisResultData:
@@ -104,7 +98,11 @@ class AnalysisResultData:
             ret += f"\nUpdated at: {self.updated_datetime}"
         return ret
 
-    def __getitem__(self, item):
-        if hasattr(self, item):
-            return getattr(self, item)
-        return None
+exp1 = ExperimentData()
+exp2 = ExperimentData()
+exp1.tags.append("foo")
+exp2.tags.append("bar")
+
+print(exp1)
+print("****")
+print(exp2)

--- a/qiskit_ibm_experiment/service/ibm_experiment_service.py
+++ b/qiskit_ibm_experiment/service/ibm_experiment_service.py
@@ -1095,7 +1095,7 @@ class IBMExperimentService:
             marker = raw_data.get("marker")
             for result in raw_data["analysis_results"]:
                 analysis_result_data_dict = self._api_to_analysis_result(result)
-                results.append(**analysis_result_data_dict)
+                results.append(AnalysisResultData(**analysis_result_data_dict))
             if limit:
                 limit -= len(raw_data["analysis_results"])
             if not marker:  # No more experiments to return.

--- a/qiskit_ibm_experiment/service/ibm_experiment_service.py
+++ b/qiskit_ibm_experiment/service/ibm_experiment_service.py
@@ -29,7 +29,7 @@ from .constants import (
 )
 from .utils import map_api_error, local_to_utc_str, utc_to_local
 from .device_component import DeviceComponent
-from .dataclasses import ExperimentData, AnalysisResultData
+from .experiment_dataclasses import ExperimentData, AnalysisResultData
 from ..client.experiment import ExperimentClient
 from ..exceptions import RequestsApiError, IBMApiError
 from ..accounts import AccountManager, Account, ProxyConfiguration

--- a/qiskit_ibm_experiment/service/ibm_experiment_service.py
+++ b/qiskit_ibm_experiment/service/ibm_experiment_service.py
@@ -29,6 +29,7 @@ from .constants import (
 )
 from .utils import map_api_error, local_to_utc_str, utc_to_local
 from .device_component import DeviceComponent
+from .dataclasses import ExperimentData, AnalysisResultData
 from ..client.experiment import ExperimentClient
 from ..exceptions import RequestsApiError, IBMApiError
 from ..accounts import AccountManager, Account, ProxyConfiguration
@@ -447,7 +448,7 @@ class IBMExperimentService:
         self,
         experiment_id: str,
         json_decoder: Type[json.JSONDecoder] = json.JSONDecoder,
-    ) -> Dict:
+    ) -> ExperimentData:
         """Retrieve a previously stored experiment.
 
         Args:
@@ -463,7 +464,8 @@ class IBMExperimentService:
         """
         with map_api_error(f"Experiment {experiment_id} not found."):
             raw_data = self._api_client.experiment_get(experiment_id)
-        return self._api_to_experiment_data(json.loads(raw_data, cls=json_decoder))
+        experiment_data_dict = self._api_to_experiment_data(json.loads(raw_data, cls=json_decoder))
+        return ExperimentData(**experiment_data_dict)
 
     def experiments(
         self,
@@ -488,7 +490,7 @@ class IBMExperimentService:
         parent_id: Optional[str] = None,
         sort_by: Optional[Union[str, List[str]]] = None,
         **filters: Any,
-    ) -> List[Dict]:
+    ) -> List[ExperimentData]:
         """Retrieve all experiments, with optional filtering.
 
         By default, results returned are as inclusive as possible. For example,
@@ -643,7 +645,8 @@ class IBMExperimentService:
             raw_data = json.loads(response, cls=json_decoder)
             marker = raw_data.get("marker")
             for exp in raw_data["experiments"]:
-                experiments.append(self._api_to_experiment_data(exp))
+                experiment_data_dict = self._api_to_experiment_data(exp)
+                experiments.append(ExperimentData(**experiment_data_dict))
             if limit:
                 limit -= len(raw_data["experiments"])
             if not marker:  # No more experiments to return.
@@ -920,7 +923,7 @@ class IBMExperimentService:
 
     def analysis_result(
         self, result_id: str, json_decoder: Type[json.JSONDecoder] = json.JSONDecoder
-    ) -> Dict:
+    ) -> AnalysisResultData:
         """Retrieve a previously stored analysis result.
 
         Args:
@@ -937,7 +940,8 @@ class IBMExperimentService:
         with map_api_error(f"Analysis result {result_id} not found."):
             raw_data = self._api_client.analysis_result_get(result_id)
 
-        return self._api_to_analysis_result(json.loads(raw_data, cls=json_decoder))
+        analysis_result_data_dict = self._api_to_analysis_result(json.loads(raw_data, cls=json_decoder))
+        return AnalysisResultData(**analysis_result_data_dict)
 
     def analysis_results(
         self,
@@ -959,7 +963,7 @@ class IBMExperimentService:
         creation_datetime_before: Optional[datetime] = None,
         sort_by: Optional[Union[str, List[str]]] = None,
         **filters: Any,
-    ) -> List[Dict]:
+    ) -> List[AnalysisResultData]:
         """Retrieve all analysis results, with optional filtering.
 
         Args:
@@ -1086,7 +1090,8 @@ class IBMExperimentService:
             raw_data = json.loads(response, cls=json_decoder)
             marker = raw_data.get("marker")
             for result in raw_data["analysis_results"]:
-                results.append(self._api_to_analysis_result(result))
+                analysis_result_data_dict = self._api_to_analysis_result(result)
+                results.append(**analysis_result_data_dict)
             if limit:
                 limit -= len(raw_data["analysis_results"])
             if not marker:  # No more experiments to return.

--- a/qiskit_ibm_experiment/service/ibm_experiment_service.py
+++ b/qiskit_ibm_experiment/service/ibm_experiment_service.py
@@ -464,7 +464,9 @@ class IBMExperimentService:
         """
         with map_api_error(f"Experiment {experiment_id} not found."):
             raw_data = self._api_client.experiment_get(experiment_id)
-        experiment_data_dict = self._api_to_experiment_data(json.loads(raw_data, cls=json_decoder))
+        experiment_data_dict = self._api_to_experiment_data(
+            json.loads(raw_data, cls=json_decoder)
+        )
         return ExperimentData(**experiment_data_dict)
 
     def experiments(
@@ -940,7 +942,9 @@ class IBMExperimentService:
         with map_api_error(f"Analysis result {result_id} not found."):
             raw_data = self._api_client.analysis_result_get(result_id)
 
-        analysis_result_data_dict = self._api_to_analysis_result(json.loads(raw_data, cls=json_decoder))
+        analysis_result_data_dict = self._api_to_analysis_result(
+            json.loads(raw_data, cls=json_decoder)
+        )
         return AnalysisResultData(**analysis_result_data_dict)
 
     def analysis_results(
@@ -1257,7 +1261,6 @@ class IBMExperimentService:
             "quality": quality,
             "verified": raw_data.get("verified", False),
             "tags": raw_data.get("tags", []),
-            "service": self,
             **extra_data,
         }
         return out_dict

--- a/test/service/test_experiment_server_integration.py
+++ b/test/service/test_experiment_server_integration.py
@@ -611,7 +611,7 @@ class TestExperimentServerIntegration(IBMTestCase):
             "end_datetime",
             "updated_datetime",
         ]:
-            if dt_attr in new_exp:
+            if new_exp[dt_attr] is not None:
                 self.assertTrue(new_exp[dt_attr].tzinfo)
 
     def test_update_experiment(self):
@@ -711,7 +711,7 @@ class TestExperimentServerIntegration(IBMTestCase):
             self.assertIsInstance(res["result_data"], dict)
             self.assertTrue(res["result_id"], "{} does not have an uuid!".format(res))
             for dt_attr in ["creation_datetime", "updated_datetime"]:
-                if dt_attr in res:
+                if res["dt_attr"] is not None:
                     self.assertTrue(res[dt_attr].tzinfo)
             if res["result_id"] == result_id:
                 found = True
@@ -1055,7 +1055,6 @@ class TestExperimentServerIntegration(IBMTestCase):
         # Create an analysis_result and get it back to get its creation_datetime value.
         result1_id = self._create_analysis_result()
         result1 = self.service.analysis_result(result1_id)
-        self.assertIn("creation_datetime", result1)
         self.assertIsNotNone(result1["creation_datetime"])
         cdt1 = result1["creation_datetime"]
         # Assert that the UTC timestamp was converted to the local time.
@@ -1208,7 +1207,7 @@ class TestExperimentServerIntegration(IBMTestCase):
             metadata=metadata, json_encoder=ExperimentEncoder
         )
         rexp = self.service.experiment(expr_id, json_decoder=ExperimentDecoder)
-        rmetadata = rexp["metadata"]
+        rmetadata = rexp.metadata
         self.assertEqual(metadata["complex"], rmetadata["complex"])
         self.assertTrue((metadata["numpy"] == rmetadata["numpy"]).all())
 
@@ -1217,7 +1216,7 @@ class TestExperimentServerIntegration(IBMTestCase):
             expr_id, metadata=new_metadata, json_encoder=ExperimentEncoder
         )
         rexp = self.service.experiment(expr_id, json_decoder=ExperimentDecoder)
-        rmetadata = rexp["metadata"]
+        rmetadata = rexp.metadata
         self.assertEqual(new_metadata["complex"], rmetadata["complex"])
         self.assertTrue((new_metadata["numpy"] == rmetadata["numpy"]).all())
 
@@ -1230,7 +1229,7 @@ class TestExperimentServerIntegration(IBMTestCase):
         rresult = self.service.analysis_result(
             result_id, json_decoder=ExperimentDecoder
         )
-        rdata = rresult["result_data"]
+        rdata = rresult.result_data
         self.assertEqual(data["complex"], rdata["complex"])
         self.assertTrue((data["numpy"] == rdata["numpy"]).all())
         self.assertEqual(data["numpy_int"], rdata["numpy_int"])
@@ -1242,7 +1241,7 @@ class TestExperimentServerIntegration(IBMTestCase):
         rresult = self.service.analysis_result(
             result_id, json_decoder=ExperimentDecoder
         )
-        rdata = rresult["result_data"]
+        rdata = rresult.result_data
         self.assertEqual(new_data["complex"], rdata["complex"])
         self.assertTrue((new_data["numpy"] == rdata["numpy"]).all())
         self.assertEqual(new_data["numpy_int"], rdata["numpy_int"])

--- a/test/service/test_experiment_server_integration.py
+++ b/test/service/test_experiment_server_integration.py
@@ -154,7 +154,7 @@ class TestExperimentServerIntegration(IBMTestCase):
         found = False
         for exp in experiments:
             self.assertEqual(parent_id, exp["parent_id"])
-            if exp["experiment_id"] == child_id:
+            if exp.experiment_id == child_id:
                 found = True
         self.assertTrue(
             found,
@@ -171,7 +171,7 @@ class TestExperimentServerIntegration(IBMTestCase):
         experiments = self.get_experiments(
             experiment_type="foo", experiment_type_operator="like"
         )
-        self.assertNotIn(exp_id, [exp["experiment_id"] for exp in experiments])
+        self.assertNotIn(exp_id, [exp.experiment_id for exp in experiments])
 
         subtests = ["qiskit", "test"]
         for filter_type in subtests:
@@ -182,9 +182,9 @@ class TestExperimentServerIntegration(IBMTestCase):
                 found = False
                 for exp in experiments:
                     self.assertTrue(
-                        re.match(f".*{filter_type}.*", exp["experiment_type"])
+                        re.match(f".*{filter_type}.*", exp.experiment_type)
                     )
-                    if exp["experiment_id"] == exp_id:
+                    if exp.experiment_id == exp_id:
                         found = True
                 self.assertTrue(
                     found,
@@ -224,10 +224,10 @@ class TestExperimentServerIntegration(IBMTestCase):
                 found = False
                 for exp in backend_experiments:
                     if start_dt:
-                        self.assertGreaterEqual(exp["start_datetime"], start_dt)
+                        self.assertGreaterEqual(exp.start_datetime, start_dt)
                     if end_dt:
-                        self.assertLessEqual(exp["start_datetime"], end_dt)
-                    if exp["experiment_id"] == exp_id:
+                        self.assertLessEqual(exp.start_datetime, end_dt)
+                    if exp.experiment_id == exp_id:
                         found = True
                 self.assertEqual(
                     found,
@@ -258,17 +258,17 @@ class TestExperimentServerIntegration(IBMTestCase):
                 ref_expr_found = False
                 for expr in experiments:
                     msg = "Tags {} not fond in experiment tags {}".format(
-                        tags, expr["tags"]
+                        tags, expr.tags
                     )
                     if operator == "AND":
                         self.assertTrue(
-                            all(f_tag in expr["tags"] for f_tag in tags), msg
+                            all(f_tag in expr.tags for f_tag in tags), msg
                         )
                     else:
                         self.assertTrue(
-                            any(f_tag in expr["tags"] for f_tag in tags), msg
+                            any(f_tag in expr.tags for f_tag in tags), msg
                         )
-                    if expr["experiment_id"] == exp_id:
+                    if expr.experiment_id == exp_id:
                         ref_expr_found = True
                 self.assertTrue(
                     ref_expr_found == found,
@@ -295,7 +295,7 @@ class TestExperimentServerIntegration(IBMTestCase):
                 for expr in hgp_experiments:
                     for hgp_key, hgp_val in hgp_kwargs.items():
                         self.assertEqual(expr[hgp_key], hgp_val)
-                    if expr["experiment_id"] == exp_id:
+                    if expr.experiment_id == exp_id:
                         ref_expr_found = True
                 self.assertTrue(ref_expr_found)
 
@@ -429,9 +429,9 @@ class TestExperimentServerIntegration(IBMTestCase):
                 experiment["owner"],
                 exp_owner,  # pylint: disable=no-member
                 "Only my experiments should be returned with mine_only filter: %s"
-                % experiment["experiment_id"],
+                % experiment.experiment_id,
             )
-            my_experiment_uuids.append(experiment["experiment_id"])
+            my_experiment_uuids.append(experiment.experiment_id)
         self.assertIn(
             exp_id,
             my_experiment_uuids,
@@ -524,7 +524,7 @@ class TestExperimentServerIntegration(IBMTestCase):
         experiments = self.get_experiments(device_components=self.device_components)
         self.assertIn(
             expr_id,
-            [expr["experiment_id"] for expr in experiments],
+            [expr.experiment_id for expr in experiments],
             f"Experiment {expr_id} not found when filtering with "
             f"device components {self.device_components}",
         )
@@ -546,7 +546,7 @@ class TestExperimentServerIntegration(IBMTestCase):
 
         self.assertIn(
             expr_id,
-            [expr["experiment_id"] for expr in experiments],
+            [expr.experiment_id for expr in experiments],
             f"Experiment {expr_id} not found when filtering with "
             f"device components {device_components[:2]}",
         )
@@ -586,23 +586,23 @@ class TestExperimentServerIntegration(IBMTestCase):
         new_exp = self.service.experiment(new_exp_id)
 
         credentials = self.provider.credentials
-        self.assertEqual(credentials.hub, new_exp["hub"])  # pylint: disable=no-member
+        self.assertEqual(credentials.hub, new_exp.hub)  # pylint: disable=no-member
         self.assertEqual(
-            credentials.group, new_exp["group"]
+            credentials.group, new_exp.group
         )  # pylint: disable=no-member
         self.assertEqual(
-            credentials.project, new_exp["project"]
+            credentials.project, new_exp.project
         )  # pylint: disable=no-member
-        self.assertEqual("qiskit_test", new_exp["experiment_type"])
-        self.assertEqual(self.backend.name(), new_exp["backend"])
-        self.assertEqual({"foo": "bar"}, new_exp["metadata"])
-        self.assertEqual(["job1", "job2"], new_exp["job_ids"])
-        self.assertEqual(["qiskit_test"], new_exp["tags"])
-        self.assertEqual("some notes", new_exp["notes"])
-        self.assertEqual(ExperimentShareLevel.PROJECT.value, new_exp["share_level"])
-        self.assertTrue(new_exp["creation_datetime"])
+        self.assertEqual("qiskit_test", new_exp.experiment_type)
+        self.assertEqual(self.backend.name(), new_exp.backend)
+        self.assertEqual({"foo": "bar"}, new_exp.metadata)
+        self.assertEqual(["job1", "job2"], new_exp.job_ids)
+        self.assertEqual(["qiskit_test"], new_exp.tags)
+        self.assertEqual("some notes", new_exp.notes)
+        self.assertEqual(ExperimentShareLevel.PROJECT.value, new_exp.share_level)
+        self.assertTrue(new_exp.creation_datetime)
         self.assertIsNotNone(
-            new_exp["owner"], "Owner should be set"
+            new_exp.owner, "Owner should be set"
         )  # pylint: disable=no-member
 
         for dt_attr in [
@@ -611,8 +611,8 @@ class TestExperimentServerIntegration(IBMTestCase):
             "end_datetime",
             "updated_datetime",
         ]:
-            if new_exp[dt_attr] is not None:
-                self.assertTrue(new_exp[dt_attr].tzinfo)
+            datetime_attr = getattr(new_exp, dt_attr)
+            self.assertTrue(datetime_attr is None or datetime_attr.tzinfo)
 
     def test_update_experiment(self):
         """Test updating an experiment."""
@@ -666,17 +666,17 @@ class TestExperimentServerIntegration(IBMTestCase):
         )
 
         rresult = self.service.analysis_result(aresult_id)
-        self.assertEqual(exp_id, rresult["experiment_id"])
-        self.assertEqual("qiskit_test", rresult["result_type"])
-        self.assertEqual(fit, rresult["result_data"])
+        self.assertEqual(exp_id, rresult.experiment_id)
+        self.assertEqual("qiskit_test", rresult.result_type)
+        self.assertEqual(fit, rresult.result_data)
         self.assertEqual(
-            self.device_components, [str(comp) for comp in rresult["device_components"]]
+            self.device_components, [str(comp) for comp in rresult.device_components]
         )
-        self.assertEqual(["qiskit_test"], rresult["tags"])
-        self.assertEqual(ResultQuality.GOOD, rresult["quality"])
-        self.assertTrue(rresult["verified"])
-        self.assertEqual(result_id, rresult["result_id"])
-        self.assertEqual(chisq, rresult["chisq"])
+        self.assertEqual(["qiskit_test"], rresult.tags)
+        self.assertEqual(ResultQuality.GOOD, rresult.quality)
+        self.assertTrue(rresult.verified)
+        self.assertEqual(result_id, rresult.result_id)
+        self.assertEqual(chisq, rresult.chisq)
 
     def test_update_analysis_result(self):
         """Test updating an analysis result."""
@@ -694,12 +694,12 @@ class TestExperimentServerIntegration(IBMTestCase):
         )
 
         rresult = self.service.analysis_result(result_id)
-        self.assertEqual(result_id, rresult["result_id"])
-        self.assertEqual(fit, rresult["result_data"])
-        self.assertEqual(["qiskit_test"], rresult["tags"])
-        self.assertEqual(ResultQuality.GOOD, rresult["quality"])
-        self.assertTrue(rresult["verified"])
-        self.assertEqual(chisq, rresult["chisq"])
+        self.assertEqual(result_id, rresult.result_id)
+        self.assertEqual(fit, rresult.result_data)
+        self.assertEqual(["qiskit_test"], rresult.tags)
+        self.assertEqual(ResultQuality.GOOD, rresult.quality)
+        self.assertTrue(rresult.verified)
+        self.assertEqual(chisq, rresult.chisq)
 
     def test_analysis_results(self):
         """Test retrieving all analysis results."""
@@ -707,13 +707,13 @@ class TestExperimentServerIntegration(IBMTestCase):
         results = self.service.analysis_results()
         found = False
         for res in results:
-            self.assertIsInstance(res["verified"], bool)
-            self.assertIsInstance(res["result_data"], dict)
-            self.assertTrue(res["result_id"], "{} does not have an uuid!".format(res))
+            self.assertIsInstance(res.verified, bool)
+            self.assertIsInstance(res.result_data, dict)
+            self.assertTrue(res.result_id, "{} does not have an uuid!".format(res))
             for dt_attr in ["creation_datetime", "updated_datetime"]:
-                if res["dt_attr"] is not None:
-                    self.assertTrue(res[dt_attr].tzinfo)
-            if res["result_id"] == result_id:
+                if hasattr(res, dt_attr):
+                    self.assertTrue(getattr(res, dt_attr).tzinfo)
+            if res.result_id == result_id:
                 found = True
         self.assertTrue(found)
 
@@ -729,9 +729,9 @@ class TestExperimentServerIntegration(IBMTestCase):
         found = False
         for res in results:
             self.assertEqual(
-                self.device_components, [str(comp) for comp in res["device_components"]]
+                self.device_components, [str(comp) for comp in res.device_components]
             )
-            if res["result_id"] == result_id:
+            if res.result_id == result_id:
                 found = True
         self.assertTrue(
             found,
@@ -758,9 +758,9 @@ class TestExperimentServerIntegration(IBMTestCase):
         for res in results:
             self.assertTrue(
                 set(device_components[:2])
-                <= {str(comp) for comp in res["device_components"]}
+                <= {str(comp) for comp in res.device_components}
             )
-            if res["result_id"] == result_id:
+            if res.result_id == result_id:
                 found = True
         self.assertTrue(
             found,
@@ -777,7 +777,7 @@ class TestExperimentServerIntegration(IBMTestCase):
         results = self.service.analysis_results(experiment_id=expr_id)
         self.assertEqual(2, len(results))
         self.assertEqual(
-            {result_id1, result_id2}, {res["result_id"] for res in results}
+            {result_id1, result_id2}, {res.result_id for res in results}
         )
 
     def test_analysis_results_with_created_at(self):
@@ -808,10 +808,10 @@ class TestExperimentServerIntegration(IBMTestCase):
                 found = False
                 for result in analysis_results:
                     if start_dt:
-                        self.assertGreaterEqual(result["creation_datetime"], start_dt)
+                        self.assertGreaterEqual(result.creation_datetime, start_dt)
                     if end_dt:
-                        self.assertLessEqual(result["creation_datetime"], end_dt)
-                    if result["result_id"] == result_id:
+                        self.assertLessEqual(result.creation_datetime, end_dt)
+                    if result.result_id == result_id:
                         found = True
                 self.assertEqual(
                     found,
@@ -829,8 +829,8 @@ class TestExperimentServerIntegration(IBMTestCase):
         results = self.service.analysis_results(result_type=result_type)
         found = False
         for res in results:
-            self.assertEqual(result_type, res["result_type"])
-            if res["result_id"] == result_id:
+            self.assertEqual(result_type, res.result_type)
+            if res.result_id == result_id:
                 found = True
         self.assertTrue(
             found,


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
This PR changes the output of `experiment()`, `experiments()`, `analysis_result()` and `analysis_results()` methods to return a dedicated dataclass instead of dictionaries, to enable smoother integration with `qiskit_experiments`.


### Details and comments


