### PR TITLE
Remove _DEFAULT_URL_BASE

### DIFF
--- a/qiskit_ibm_experiment/client/experiment_rest_adapter.py
+++ b/qiskit_ibm_experiment/client/experiment_rest_adapter.py
@@ -38,7 +38,6 @@ class ExperimentRestAdapter:
     }
 
     _HEADER_JSON_CONTENT = {"Content-Type": "application/json"}
-    _DEFAULT_URL_BASE = "https://api.quantum-computing.ibm.com/resultsdb"
 
     def __init__(self, session: RetrySession, prefix_url: str = "") -> None:
         """ExperimentRestAdapter constructor.


### PR DESCRIPTION

### Summary

This is unused from what I can tell. If it were used, it should be
changed to https://resultsdb.quantum-computing.ibm.com because
the old sub-route on api.quantum-computing.ibm.com is going away
soon.

### Details and comments

n/a

