### PR TITLE
Remove plots from URL_MAP

### DIFF
--- a/qiskit_ibm_experiment/client/experiment_rest_adapter.py
+++ b/qiskit_ibm_experiment/client/experiment_rest_adapter.py
@@ -29,7 +29,6 @@ class ExperimentRestAdapter:
         "experiments": "/experiments",
         "analysis_results": "/analysis_results",
         "analysis_result": "/analysis_results/{uuid}",
-        "plots": "/experiments/{uuid}/plots",
         "plot": "/experiments/{uuid}/plots/{name}",
         "plot_upload": "/experiments/{uuid}/plots/upload/{name}",
         "files": "/experiments/{uuid}/files",


### PR DESCRIPTION

### Summary

#33 removed the need for this. We should remove it from
URL_MAP to avoid confusion over which plot APIs are being
used, since there are now multiple available for creating a
plot resource.

### Details and comments

n/a

