### PR TITLE
Multiple figures upload

### DIFF
--- a/qiskit_ibm_experiment/service/ibm_experiment_service.py
+++ b/qiskit_ibm_experiment/service/ibm_experiment_service.py
@@ -1429,7 +1429,7 @@ class IBMExperimentService:
     def create_figures(
         self,
         experiment_id: str,
-        figure_list: List[Tuple[Union[str,bytes], str]],
+        figure_list: List[Tuple[Union[str, bytes], str]],
         blocking: bool = True,
         max_workers: int = 100,
     ):
@@ -1456,7 +1456,10 @@ class IBMExperimentService:
             IBMExperimentEntryExists: If the figure already exits.
             IBMApiError: If the request to the server failed.
         """
-        figure_params = [(experiment_id, figure, figure_name) for (figure, figure_name) in figure_list]
+        figure_params = [
+            (experiment_id, figure, figure_name)
+            for (figure, figure_name) in figure_list
+        ]
         handler = ThreadSaveHandler(
             figure_params,
             self.create_or_update_figure,

--- a/qiskit_ibm_experiment/service/ibm_experiment_service.py
+++ b/qiskit_ibm_experiment/service/ibm_experiment_service.py
@@ -1426,6 +1426,49 @@ class IBMExperimentService:
             return None
         return figure_name, len(figure)
 
+    def create_figures(
+        self,
+        experiment_id: str,
+        figure_list: List[Tuple[Union[str,bytes], str]],
+        blocking: bool = True,
+        max_workers: int = 100,
+    ):
+        """Create multiple figures in the database using asynchronous calls.
+
+        If you choose `blocking==True`, the method will run until all the save threads terminated.
+        To improve running time, multithreading is used.
+
+        If `blocking==False` it is up to the user to verify all the threads finished;
+        `block_for_save()` can be called to ensure all threads finish.
+        `save_status()` returns the information on the status of the threads.
+
+        Args:
+            experiment_id: ID of the experiment this figure is for.
+            figure_list: A list of the figures to save.
+                Every figure is given by a tuple of the form (figure, name)
+                where `figure` can be the actual figure or its filename
+                and `name` is the name given to the figure in the db.
+                If ``None``, the figure file name, if given, or a generated name is used.
+            blocking: Whether to wait for all the save threads to finish before returning control
+            max_workers: Maximum number of worker threads to write to the server.
+
+        Raises:
+            IBMExperimentEntryExists: If the figure already exits.
+            IBMApiError: If the request to the server failed.
+        """
+        figure_params = [(experiment_id, figure, figure_name) for (figure, figure_name) in figure_list]
+        handler = ThreadSaveHandler(
+            figure_params,
+            self.create_or_update_figure,
+            max_workers,
+            create=True,
+            max_attempts=3,
+        )
+        if blocking:
+            handler.block_for_save()
+            return handler.save_status()
+        return handler
+
     def update_figure(
         self,
         experiment_id: str,

--- a/qiskit_ibm_experiment/service/utils.py
+++ b/qiskit_ibm_experiment/service/utils.py
@@ -15,12 +15,10 @@
 import logging
 import os
 from concurrent import futures
-from typing import Generator, Union, Optional, List
+from typing import Generator, Union, Optional, List, Tuple
 from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
 import dateutil
-from pandas import DataFrame
-from .experiment_dataclasses import AnalysisResultData
 
 from ..exceptions import (
     IBMExperimentEntryNotFound,
@@ -187,7 +185,7 @@ class ThreadSaveHandler:
 
     def __init__(
         self,
-        data: Union[List[AnalysisResultData], DataFrame],
+        data: List[Tuple],
         save_method,
         max_workers: int = 100,
         **kwargs,
@@ -197,10 +195,11 @@ class ThreadSaveHandler:
         self._save_data = {}
         self._running_tasks = []
         for result_data in data:
-            # cid = uuid.uuid4().hex
+            if not isinstance(result_data, tuple):
+                result_data = (result_data,)
             task = {
                 "data": result_data,
-                "future": save_executor.submit(save_method, result_data, **kwargs),
+                "future": save_executor.submit(save_method, *result_data, **kwargs),
             }
             self._running_tasks.append(task)
         self._successful_tasks = []

--- a/releasenotes/notes/multiple_figure_upload-fd2af6445c520ad5.yaml
+++ b/releasenotes/notes/multiple_figure_upload-fd2af6445c520ad5.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Added the `create_figures` method for uploading multiple figures concurrently.

--- a/test/service/test_experiment_data_integration.py
+++ b/test/service/test_experiment_data_integration.py
@@ -140,15 +140,16 @@ class TestExperimentDataIntegration(IBMTestCase):
             exp_data.add_jobs(job)
             job_ids.append(job.job_id())
 
-        exp_data.save()
+        exp_data.block_for_results().save()
         self.experiments_to_delete.append(exp_data.experiment_id)
 
-        credentials = self.backend.provider().credentials
+        hub, group, project = list(self.backend.provider._hgps)[0].split("/")
+
         rexp = ExperimentData.load(exp_data.experiment_id, self.service)
         self._verify_experiment_data(exp_data, rexp)
-        self.assertEqual(credentials.hub, rexp.hub)  # pylint: disable=no-member
-        self.assertEqual(credentials.group, rexp.group)  # pylint: disable=no-member
-        self.assertEqual(credentials.project, rexp.project)  # pylint: disable=no-member
+        self.assertEqual(hub, rexp.hub)  # pylint: disable=no-member
+        self.assertEqual(group, rexp.group)  # pylint: disable=no-member
+        self.assertEqual(project, rexp.project)  # pylint: disable=no-member
 
     def test_update_experiment_data(self):
         """Test updating an experiment."""
@@ -160,7 +161,7 @@ class TestExperimentDataIntegration(IBMTestCase):
         exp_data.tags = ["foo", "bar"]
         exp_data.share_level = "hub"
         exp_data.notes = "some notes"
-        exp_data.save()
+        exp_data.block_for_results().save()
 
         rexp = ExperimentData.load(exp_data.experiment_id, self.service)
         self._verify_experiment_data(exp_data, rexp)

--- a/test/service/test_experiment_server_integration.py
+++ b/test/service/test_experiment_server_integration.py
@@ -1334,14 +1334,16 @@ class TestExperimentServerIntegration(IBMTestCase):
         file_names = []
         figure_names = []
         for name in ["hello world", "another test"]:
-            bytes = str.encode(name)
+            bytes_data = str.encode(name)
             words = name.split(" ")
             file_name = f"{words[0]}_{words[1]}.svg"
             file_names.append(file_name)
             figure_names.append(f"{words[0]}.svg")
             with open(file_names[-1], "wb") as file:
-                file.write(bytes)
-            self.assertTrue(os.path.isfile(file_name), f"File {file_name} was not created")
+                file.write(bytes_data)
+            self.assertTrue(
+                os.path.isfile(file_name), f"File {file_name} was not created"
+            )
             self.addCleanup(os.remove, file_name)
 
         expr_id = self._create_experiment()


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
This PR adds the method `create_figures` which enables multithreaded upload of multiple figures.

