### PR TITLE
Change integration tests to fail if setup fails

### DIFF
--- a/test/service/test_experiment_data_integration.py
+++ b/test/service/test_experiment_data_integration.py
@@ -14,7 +14,7 @@
 
 import os
 import unittest
-from unittest import mock, SkipTest, skipIf
+from unittest import mock, skipIf
 import contextlib
 from test.service.ibm_test_case import IBMTestCase
 import numpy as np

--- a/test/service/test_experiment_data_integration.py
+++ b/test/service/test_experiment_data_integration.py
@@ -47,7 +47,7 @@ class TestExperimentDataIntegration(IBMTestCase):
             cls._setup_provider()
             cls.circuit = transpile(ReferenceCircuits.bell(), cls.backend)
         except Exception as err:
-            print(err, "Not authorized to use experiment service.")
+            cls.log.info("Error while setting the service/provider: %s", err)
             raise
 
     @classmethod

--- a/test/service/test_experiment_data_integration.py
+++ b/test/service/test_experiment_data_integration.py
@@ -47,7 +47,8 @@ class TestExperimentDataIntegration(IBMTestCase):
             cls._setup_provider()
             cls.circuit = transpile(ReferenceCircuits.bell(), cls.backend)
         except Exception as err:
-            raise SkipTest("Not authorized to use experiment service.") from err
+            print(err, "Not authorized to use experiment service.")
+            raise
 
     @classmethod
     def _setup_service(cls):

--- a/test/service/test_experiment_server_integration.py
+++ b/test/service/test_experiment_server_integration.py
@@ -47,7 +47,7 @@ class TestExperimentServerIntegration(IBMTestCase):
             cls._setup_provider()
         except Exception as err:
             cls.log.info("Error while setting the service/provider: %s", err)
-            raise SkipTest("Not authorized to use experiment service.") from err
+            raise
 
     @classmethod
     def _setup_service(cls):

--- a/test/service/test_experiment_server_integration.py
+++ b/test/service/test_experiment_server_integration.py
@@ -17,7 +17,7 @@ import uuid
 import unittest
 import json
 import re
-from unittest import mock, SkipTest, skipIf
+from unittest import mock, skipIf
 from datetime import datetime, timedelta
 from typing import Optional, Dict, Any
 from test.service.ibm_test_case import IBMTestCase


### PR DESCRIPTION
Currently if the provider fails during `setUpClass`, the tests are skipped and the output status is still successful. This changes the behavior so that the tests fail if this happens.